### PR TITLE
ci(workflows): enable auto patch version bump in PR and streamline re…

### DIFF
--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -3,10 +3,10 @@ name: PR Version Validation
 on:
   pull_request:
     branches: [main]
-    paths: ['package.json']
+    types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 
@@ -23,12 +23,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install semver for validation
         run: npm install --no-save semver
 
       - name: Validate Version Bump
+        id: validate-version
         run: |
           # Get version from PR branch
           PR_VERSION=$(node -p "require('./package.json').version")
@@ -99,10 +100,29 @@ jobs:
             
           else
             echo "ℹ️  No manual version change detected"
-            echo "📋 This is normal - auto-bump will occur after merge to main"
+            echo "📋 Will auto-bump patch version in this PR"
             echo "   • Patch version will be incremented automatically"
             echo "   • Example: $MAIN_VERSION → $(echo $MAIN_VERSION | awk -F. '{print $1"."$2"."($3+1)}')"
+            echo "auto-bump-needed=true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Auto Bump Version in PR
+        if: steps.validate-version.outputs.auto-bump-needed == 'true'
+        run: |
+          # Configure git
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+          # Bump patch version
+          npm version patch --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+
+          # Commit and push the version bump to the PR branch
+          git add package.json package-lock.json
+          git commit -m "chore: auto-bump version to $NEW_VERSION"
+          git push
+
+          echo "🚀 Auto-bumped version to $NEW_VERSION in PR"
 
       - name: Comment on PR
         uses: actions/github-script@v7
@@ -129,7 +149,6 @@ jobs:
             ✅ **Validation Status**: Version bump is valid and follows semantic versioning
 
             ### What happens after merge:
-            - ⏭️ Auto-bump will be **skipped** (manual version detected)
             - 🏷️ Git tag \`v${prVersion}\` will be created
             - 📋 GitHub release will be generated automatically
             - 📦 Package will be published to NPM registry
@@ -139,17 +158,17 @@ jobs:
               const semver = require('semver');
               const nextPatch = semver.inc(mainVersion, 'patch');
               
-              body = `## 📦 No Version Change Detected
+              body = `## 📦 Auto Version Bump Applied
 
-            📋 **Current Version**: \`${mainVersion}\`
+            📋 **Previous Version**: \`${mainVersion}\`
+            🚀 **New Version**: \`${nextPatch}\` (auto-bumped)
 
             ### What happens after merge:
-            - 🔄 Version will be auto-bumped to \`${nextPatch}\` (patch increment)
             - 🏷️ Git tag \`v${nextPatch}\` will be created  
             - 📋 GitHub release will be generated automatically
             - 📦 Package will be published to NPM registry
 
-            > 💡 This is the normal flow for regular updates and bug fixes!`;
+            > 💡 Version was automatically incremented since no manual bump was detected in this PR!`;
             }
 
             // Post comment with error handling

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -113,6 +115,9 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
+          # Ensure we're on the correct branch
+          git checkout ${{ github.head_ref }}
+
           # Bump patch version
           npm version patch --no-git-tag-version
           NEW_VERSION=$(node -p "require('./package.json').version")
@@ -120,7 +125,7 @@ jobs:
           # Commit and push the version bump to the PR branch
           git add package.json package-lock.json
           git commit -m "chore: auto-bump version to $NEW_VERSION"
-          git push
+          git push origin ${{ github.head_ref }}
 
           echo "🚀 Auto-bumped version to $NEW_VERSION in PR"
 

--- a/.github/workflows/pr-version-check.yml
+++ b/.github/workflows/pr-version-check.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   validate-version:
     runs-on: ubuntu-latest
+    if: github.head_ref == 'develop'
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,6 @@ name: Version Bump and Release
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [closed]
-    branches: [main]
 
 permissions:
   contents: write
@@ -15,7 +12,6 @@ permissions:
 
 jobs:
   version-and-release:
-    if: github.event.pull_request.merged == true || github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -28,67 +24,23 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies
         run: npm ci
 
-      - name: Detect Version Changes
-        id: version-check
-        run: |
-          # Get current version
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-
-          # Get version from previous commit (if exists)
-          if git rev-parse HEAD~1 >/dev/null 2>&1; then
-            git show HEAD~1:package.json > prev_package.json 2>/dev/null || echo '{"version":"0.0.0"}' > prev_package.json
-            PREVIOUS_VERSION=$(node -p "require('./prev_package.json').version")
-            rm -f prev_package.json
-          else
-            PREVIOUS_VERSION="0.0.0"
-          fi
-
-          echo "current-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "previous-version=$PREVIOUS_VERSION" >> $GITHUB_OUTPUT
-
-          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
-            echo "version-changed=true" >> $GITHUB_OUTPUT
-            echo "✅ Manual version change detected: $PREVIOUS_VERSION → $CURRENT_VERSION"
-          else
-            echo "version-changed=false" >> $GITHUB_OUTPUT
-            echo "ℹ️  No version change detected. Will auto-bump patch version."
-          fi
-
-      - name: Auto Bump Version
-        if: steps.version-check.outputs.version-changed == 'false'
-        run: |
-          # Configure git
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-
-          # Bump patch version
-          npm version patch --no-git-tag-version
-          NEW_VERSION=$(node -p "require('./package.json').version")
-
-          # Commit the version bump
-          git add package.json package-lock.json
-          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
-          git push
-
-          echo "🚀 Auto-bumped version to $NEW_VERSION"
-
-      - name: Get Final Version
-        id: final-version
+      - name: Get Current Version
+        id: version
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Final version: $VERSION"
+          echo "Current version: $VERSION"
 
       - name: Check if Release Exists
         id: release-check
         run: |
-          TAG="v${{ steps.final-version.outputs.version }}"
+          TAG="v${{ steps.version.outputs.version }}"
 
           # Check if tag already exists
           if git rev-parse "$TAG" >/dev/null 2>&1; then
@@ -150,7 +102,7 @@ jobs:
       - name: Create Git Tag
         if: steps.release-check.outputs.tag-exists == 'false'
         run: |
-          TAG="v${{ steps.final-version.outputs.version }}"
+          TAG="v${{ steps.version.outputs.version }}"
           git tag "$TAG"
           git push origin "$TAG"
           echo "🏷️  Created and pushed tag: $TAG"
@@ -159,7 +111,7 @@ jobs:
         if: steps.release-check.outputs.tag-exists == 'false'
         id: release-notes
         run: |
-          VERSION="${{ steps.final-version.outputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
 
           # Get the last tag (if any)
           LAST_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
@@ -230,8 +182,8 @@ jobs:
         if: steps.release-check.outputs.tag-exists == 'false'
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: 'v${{ steps.final-version.outputs.version }}'
-          name: 'Release v${{ steps.final-version.outputs.version }}'
+          tag_name: 'v${{ steps.version.outputs.version }}'
+          name: 'Release v${{ steps.version.outputs.version }}'
           body_path: ${{ steps.release-notes.outputs.notes-file }}
           draft: false
           prerelease: false
@@ -253,13 +205,13 @@ jobs:
           # Publish to NPM
           npm publish --access public
 
-          echo "🎉 Successfully published v${{ steps.final-version.outputs.version }} to NPM!"
+          echo "🎉 Successfully published v${{ steps.version.outputs.version }} to NPM!"
 
       - name: Success Notification
         if: success() && steps.release-check.outputs.tag-exists == 'false'
         run: |
           echo "🎉 Release workflow completed successfully!"
-          echo "✅ Version: v${{ steps.final-version.outputs.version }}"
+          echo "✅ Version: v${{ steps.version.outputs.version }}"
           echo "✅ GitHub Release: Created"
           echo "✅ NPM Package: Published"
 
@@ -274,7 +226,7 @@ jobs:
 
             The release workflow encountered an error. Please check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
-            **Attempted Version**: v${{ steps.final-version.outputs.version || 'unknown' }}
+            **Attempted Version**: v${{ steps.version.outputs.version || 'unknown' }}
             **Workflow Run**: ${{ github.run_id }}
             **Commit**: ${{ github.sha }}`;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yae-modernize-tailwind",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yae-modernize-tailwind",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^24.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yae-modernize-tailwind",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A powerful CLI tool to automate migration of Tailwind CSS classes to newer, more efficient conventions",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
…lease workflow

- Trigger PR version check on opened, synchronize, reopened events instead of only package.json changes
- Upgrade Node.js from v18 to v20 in workflow environments
- Add auto bump step in PR workflow to patch version if no manual bump detected
- Configure GitHub action user and push the bumped version within the PR branch
- Update PR status comment to reflect auto version bump and new version details
- Remove pull_request trigger and manual version detection steps from release workflow on main branch push
- Simplify release workflow to use current package version directly without auto bumping
- Align all version output references to a single step output variable for consistency
- Clean up redundant version change detection and auto bump commit logic in release workflow